### PR TITLE
A bunch of edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# The .gitignore file stops the build directory from uploading to GitHub
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
+if(APPLE)
+# Homebrew's preferred prefix is /usr/local for macOS Intel & /opt/homebrew for Apple Silicon
+include_directories(AFTER "/opt/homebrew/include" "/usr/local/include")
+endif(APPLE)
 set(TARGET_UTIL gsc)
 
 project(${TARGET_UTIL})

--- a/README-INSTALL-MAC.md
+++ b/README-INSTALL-MAC.md
@@ -24,7 +24,7 @@ This is handled within the `CMakeLists.txt` file.
 
 Install these projects by following their install instructions (i.e. their README files)
 
-* https://github.com/la1k/libpredict
+* https://github.com/la1k/libpredict (see https://github.com/la1k/libpredict/issues/110 if it doesn't compile)
 * https://github.com/json-c/json-c
 
 Both can be installed in their default locations.

--- a/README-INSTALL-MAC.md
+++ b/README-INSTALL-MAC.md
@@ -1,0 +1,37 @@
+# Mac install instructions
+
+This should be in the wiki. After that happens, this file can be deleted.
+
+## Mac install (assuming you have brew)
+
+Nearly everything you need can be found via `brew` package handler.
+The following should be installed to allow the compilation and running of gsc.
+
+```
+brew install libconfig libev xmlrpc-c hamlib libusb dfu-util cmake
+```
+
+The following is useful independent of gsc; however, will allow easy REST API testing
+
+```
+brew install jq
+```
+
+Homebrew's preferred install location is `/usr/local` for macOS Intel and `/opt/homebrew` for newer Apple Silicon macOS.
+This is handled within the `CMakeLists.txt` file.
+
+## Packages you need to build yourself - libpredict & json-c
+
+Install these projects by following their install instructions (i.e. their README files)
+
+* https://github.com/la1k/libpredict
+* https://github.com/json-c/json-c
+
+Both can be installed in their default locations.
+Both have `sudo` style install commands (see README's).
+
+## Final notes
+
+While the Mac is a perfectly acceptable platform to operate gsc, an end user should be aware of the specifics of running hamlib and the gnuradio tools on a Mac.
+That is beyond the scope of this file.
+

--- a/sample-default.cfg
+++ b/sample-default.cfg
@@ -1,0 +1,35 @@
+#
+# Sample default.cfg configuration file - edit as needed. (see wiki)
+#
+
+# Your ground station latitude and longitude.
+latitude = 48.711
+longitude = 7.711
+
+# recalibrate antenna once per 'calibrate' trackings (useful for some buggy antenna controllers).
+calibrate = 0
+
+# port to listen REST API calls.
+request-port = 25565
+
+# TCP host and port of the azimuth and elevation rotctld process - they must be started before gsc needs to use them.
+remote-addr = "127.0.0.1"
+azimuth-port = 8080
+elevation-port = 8081
+
+# log level and file to log output into.
+verbosity = 3
+log_file = "dump.log"
+
+# The python command_handler.py program (presently pre_doit, post_doit, and ant_select functions).
+command-script = "/home/stanislavb/isu_ground_station/command_handler.py"
+
+# GNU Radio config file
+gnuradio-config = "/home/stanislavb/sdr_prototypes/master/default"
+# GNU Radio flowgraph file
+gnuradio-flowgraph = "/home/stanislavb/sdr_prototypes/master/fmDemod.py"
+
+# GNU Radio contols the SDR and the IF, BB, and LNA gain should be set as follows.
+sdr_if_gain = 0
+sdr_bb_gain = 0
+sdr_lna_gain = 0

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -22,7 +22,9 @@
 
 #include <stdbool.h>
 #include <libconfig.h>
+#ifdef  __linux__
 #include <linux/limits.h>
+#endif
 
 #define DEF_LISTEN_PORT		25565
 #define DEF_CONFIG_NAME		"default.cfg"

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -22,7 +22,7 @@ int pre_doit(observation_t *obs)
 	char freq[32] = { 0 };
 
 	if (obs->active)
-		snprintf(freq, sizeof(freq), "%d", obs->active->frequency);
+		snprintf(freq, sizeof(freq), "%llu", (long long)obs->active->frequency);
 
 	char *args[] = { DEF_CONF_PYTHON, (char *) obs->cfg->cmd_script, "pre_doit", freq, NULL };
 	return request_cmd(DEF_CONF_PYTHON, args);

--- a/src/gnuradio.c
+++ b/src/gnuradio.c
@@ -52,11 +52,11 @@ int sdr_prepare_config(cfg_t *cfg, satellite_t *sat, const char *filename)
 	}
 
 	snprintf(cfg_line, sizeof(cfg_line), "[sdr]\n"
-			"sdr_Freq=%d\n"
+			"sdr_Freq=%llu\n"
 			"sdr_IF_Gain=%d\n"
 			"sdr_BB_Gain=%d\n"
 			"sdr_LNA_Gain=%d\n",
-			sat->frequency,
+			(long long)sat->frequency,
 			cfg->if_gain,
 			cfg->bb_gain,
 			cfg->lna_gain);

--- a/src/json.c
+++ b/src/json.c
@@ -67,6 +67,25 @@ bool json_get_int_by_key(json_object *parent, const char *key, int *ret)
   return true;
 }
 
+bool json_get_uint64_by_key(json_object *parent, const char *key, uint64_t *ret)
+{
+  json_object *obj;
+
+  if (!parent || !key || !ret) {
+    return false;
+  }
+
+  if (!json_object_object_get_ex(parent, key, &obj)) {
+    return false;
+  }
+
+  if (json_object_get_type(obj) != json_type_int)
+    return false;
+
+  *ret = json_object_get_uint64(obj);
+  return true;
+}
+
 bool json_get_double_by_key(json_object *parent, const char *key, double *ret)
 {
   json_object *obj;

--- a/src/json.h
+++ b/src/json.h
@@ -24,4 +24,5 @@
 
 const char *json_get_string_by_key(json_object *parent, const char *key);
 bool json_get_int_by_key(json_object *parent, const char *key, int *ret);
+bool json_get_uint64_by_key(json_object *parent, const char *key, uint64_t *ret);
 bool json_get_double_by_key(json_object *parent, const char *key, double *ret);

--- a/src/main.c
+++ b/src/main.c
@@ -65,6 +65,7 @@ int main(int argc, char **argv)
 	int options;
 	int option_index;
 	config_t file_cfg;
+	int verbose_level = 0;	/* presently unused */
 
 	/** internal gsc config */
 	cfg = alloc_cfg();
@@ -95,6 +96,9 @@ int main(int argc, char **argv)
 		}
 
 		switch (options) {
+			case 'v':
+				verbose_level = atoi(optarg);
+				break;
 			case 'c':
 				cfg->dry_run = true;
 				break;
@@ -120,8 +124,10 @@ int main(int argc, char **argv)
 		goto err;
 	}
 
-	if (sig_register() == -1)
-		return -1;
+	if (sig_register() == -1) {
+		fprintf(stderr, "signal() register failed\n");
+		goto err;
+	}
 
 	LOG_V("Dry run:              %s", !!cfg->dry_run ? "true" : "false");
 	LOG_V("Latitude:             %f", cfg->latitude);

--- a/src/rest_api.c
+++ b/src/rest_api.c
@@ -666,7 +666,7 @@ static int rest_api_set_observation(char *payload, char **reply_buf, const char 
 
 			strncpy(sat->name, satName, sizeof(sat->name) - 1);
 
-			if (!json_get_int_by_key(satelliteObj, "frequency", &sat->frequency)) {
+			if (!json_get_uint64_by_key(satelliteObj, "frequency", &sat->frequency)) {
 				*error = "'/observation/satellite/frequency' not specified";
 				ret = -1;
 				goto out;
@@ -675,9 +675,14 @@ static int rest_api_set_observation(char *payload, char **reply_buf, const char 
 			LOG_V("Satellite frequency: [ %d ]", sat->frequency);
 
 			if (!json_get_double_by_key(satelliteObj, "min_elevation", &sat->min_elevation)) {
-				*error = "'/observation/satellite/min_elevation' not specified";
-				ret = -1;
-				goto out;
+				/* Could be just an int */
+				int temp_min_elevation;
+				if (!json_get_int_by_key(satelliteObj, "min_elevation", &temp_min_elevation)) {
+					*error = "'/observation/satellite/min_elevation' not specified";
+					ret = -1;
+					goto out;
+				}
+				sat->min_elevation = (double)temp_min_elevation;
 			}
 
 			LOG_V("Satellite min. elevation: [ %f ]", sat->min_elevation);

--- a/src/sat.c
+++ b/src/sat.c
@@ -467,7 +467,7 @@ static int sat_fetch_tle(const char *name, char *tle1, char *tle2)
 {
 	int ret;
 	int size;
-	FILE *fd;
+	FILE *fd = NULL;
 	char *buf;
 	bool found;
 

--- a/src/sat.h
+++ b/src/sat.h
@@ -94,7 +94,7 @@ typedef struct satellite_t {
 
 	double min_elevation;
 	double max_elevation;
-  	int frequency;
+  	uint64_t frequency;		/* uint64_t needed because QO-100 Es'Hail2 runs at 10Ghz and that's more than 32 bits */
   	int bandwidth;
   	int priority;
 	time_t next_aos;

--- a/start-fake-rotator-servers.sh
+++ b/start-fake-rotator-servers.sh
@@ -1,0 +1,13 @@
+:
+
+# -m1 is a dummy rotator - this will allow gsc to run without any hardware
+
+# The 8080 & 8081 come from the default.cfg file
+#   azimuth-port = 8080
+#   elevation-port = 8081
+#
+
+rotctld -v -v -v -Z -m1 -t8080 &
+rotctld -v -v -v -Z -m1 -t8081 & 
+
+wait


### PR DESCRIPTION
Here's a bunch of edits. Eleven commits as follows:
* On a Mac, you need to do some prebuild installs somewhat differently
* Based on the wiki, this is a sample configuration file complete with description
* On an Apple Mac (Intel or Apple CPU) you need some more includes
* min_elevation is an example where double or int is acceptable. The frequency value is now uint64
* fd needed to be set in order for the code to correctly pass compiler error
* verbose -v flag code was added - more to do. The return from sig_register() was made more verbose - not that it should ever be called
* json_get_uint64_by_key() added to read frequency from json and handle 10Ghz etc
* uint64_t for frequency variable is needed because QO-100 Es'Hail2 runs at 10Ghz and that's more than 32 bits
* limits.h is only on linux
* I needed a fake rotator to test code on the road
* The .gitignore file stops the build directory from uploading to GitHub
I actually think there's some more work to do with the type's in the `sat.h` file - but for now, the key one is changed. 
Please let me know if this is helpful.
